### PR TITLE
Fix deprecation warnings for Atom v1.9.0+

### DIFF
--- a/lib/auto-detect-indentation.coffee
+++ b/lib/auto-detect-indentation.coffee
@@ -21,8 +21,8 @@ module.exports =
         indentation = IndentationManager.autoDetectIndentation editor
         IndentationManager.setIndentation editor, indentation, true
 
-    if editor.displayBuffer?.onDidTokenize
-      onTokenizeDisposable = editor.displayBuffer.onDidTokenize =>
+    if editor.buffer?.onDidTokenize
+      onTokenizeDisposable = editor.buffer.onDidTokenize =>
         # This event fires when the grammar is first loaded.
         # We re-analyze the file's indentation, in order to ignore indentation inside comments
         @_attach editor


### PR DESCRIPTION
Exactly what the PR's title suggests. Fixes this:

<img width="708" alt="Figure 1" src="https://cloud.githubusercontent.com/assets/2346707/17302282/d01617d6-585e-11e6-979f-932a2ff799d9.png">
