### PR TITLE
Fix `TypeError` exception that was crashing Atom

### DIFF
--- a/lib/indentation-manager.coffee
+++ b/lib/indentation-manager.coffee
@@ -63,11 +63,13 @@ module.exports =
   setIndentation: (editor, indentation, automatic = false) ->
     unless automatic
       manuallyIndented.add(editor)
-    if "softTabs" of indentation and indentation.softTabs != null
+    
+    if indentation.softTabs?
       editor.setSoftTabs indentation.softTabs
     else
       editor.setSoftTabs atom.config.get("editor.softTabs", scope: editor.getRootScopeDescriptor().scopes)
-    if "tabLength" of indentation
+    
+    if indentation.tabLength?
       editor.setTabLength indentation.tabLength
     else
       editor.setTabLength atom.config.get("editor.tabLength", scope: editor.getRootScopeDescriptor().scopes)


### PR DESCRIPTION
This commit is a workaround for issue atom/atom#12575 in Atom core, which was causing uncaught `TypeError: Cannot read property 'screenExtent' of undefined` exceptions to be thrown by Atom, breaking it until the program was restarted. auto-detect-indentation was inadvertently triggering this bug, causing it to crash Atom in certain circumstances.

The bug was triggered by passing `null` to `editor.setTabLength()`. You can see details of the bug in the discussion at https://github.com/atom/atom/issues/12575 .

This commit changes `IndentationManager::setIndentation()` to check if `indentation.tabLength` is `null`, and to only call `editor.setTabLength()` if it isn't. I also took the opportunity to make the existing null check of `indentation.softTabs` to be more idiomatic CoffeeScript.

There should be no other behavior change to auto-detect-indentation aside from not trigger unhandled exceptions in Atom.
